### PR TITLE
Update Flush to work only when enough data available

### DIFF
--- a/S3UploadStream/S3UploadStream.cs
+++ b/S3UploadStream/S3UploadStream.cs
@@ -107,6 +107,10 @@ namespace Cppl.Utilities.AWS
 
         private void Flush(bool disposing)
         {
+            if ((_metadata.CurrentStream == null || _metadata.CurrentStream.Length < MIN_PART_LENGTH) &&
+                !disposing)
+                return;
+
             if (_metadata.UploadId == null) {
                 _metadata.UploadId = _s3.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest()
                 {
@@ -114,9 +118,7 @@ namespace Cppl.Utilities.AWS
                     Key = _metadata.Key
                 }).GetAwaiter().GetResult().UploadId;
             }
-            // INFO: Don't complete the request here.  A flush just means send the buffer.  If it's
-            // less than MIN_PART_SIZE bytes and not the last part an exception will be thrown by 
-            // S3 but c'est la vie!  Maybe that should generate a warning.
+            
             if (_metadata.CurrentStream != null)
             {
                 var i = ++_metadata.PartCount;


### PR DESCRIPTION
If the size of the part sent is less than 5MB it fails. With this change, the flush waits until there's enough information to send to S3.