### PR TITLE
Fix an issue that can cause int overflow

### DIFF
--- a/S3UploadStream/S3UploadStream.cs
+++ b/S3UploadStream/S3UploadStream.cs
@@ -258,7 +258,7 @@ namespace Cppl.Utilities.AWS
                 }
 
                 var remaining = _metadata.PartLength - _metadata.CurrentStream.Length;
-                var w = Math.Min(c, (int)remaining);
+                var w = (int)Math.Min(c, remaining);
                 _metadata.CurrentStream.Write(buffer, o, w);
 
                 _metadata.Position += w;


### PR DESCRIPTION
the issue happened to me when I used this stream. for some cases when the stream was big enough there where cases where it crashed because the count sent to CurrentStream.Write was negative. after I investigated this it appears the conversion of w to in caused an overflow.